### PR TITLE
Fixed undefined var parsed

### DIFF
--- a/lib/runkeeper.js
+++ b/lib/runkeeper.js
@@ -82,7 +82,8 @@ HealthGraph.prototype.apiCall = function(method, media_type, endpoint, callback)
 	'Authorization' : 'Bearer ' + this.access_token},
 		uri: "https://" + this.api_domain + endpoint
 	};
-	request(request_details, function(error, response, body) { 
+	request(request_details, function(error, response, body) {
+		var parsed;
 		try {
 			parsed = JSON.parse(body);
 		} catch(e) {
@@ -106,6 +107,7 @@ for (func_name in API) {
 		};
 		request(request_details,
 			function(error, response, body) { 
+				var parsed;
 				try {
 					parsed = JSON.parse(body);
 				} catch(e) {


### PR DESCRIPTION
On Node 0.10.32 I get the following error using this lib:

```
ReferenceError: parsed is not defined
    at Request._callback (/Users/filipbonnevier/projects/heatmap/node_modules/runkeeper-js/lib/runkeeper.js:115:22)
    at Request.self.callback (/Users/filipbonnevier/projects/heatmap/node_modules/runkeeper-js/node_modules/request/request.js:372:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/Users/filipbonnevier/projects/heatmap/node_modules/runkeeper-js/node_modules/request/request.js:1317:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/Users/filipbonnevier/projects/heatmap/node_modules/runkeeper-js/node_modules/request/request.js:1265:12)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
```
