### PR TITLE
Handle 403 and fix API headers.

### DIFF
--- a/lib/runkeeper.js
+++ b/lib/runkeeper.js
@@ -89,6 +89,8 @@ HealthGraph.prototype.apiCall = function(method, media_type, endpoint, callback)
 		} catch(e) {
 			error = new Error('Body reply is not a valid JSON string.');
 			error.runkeeperBody = body;
+      error.statusCode = response.statusCode;
+      error.statusMessage = response.statusMessage;
 		} finally {
 			callback(error, parsed);
 		}
@@ -113,6 +115,8 @@ for (func_name in API) {
       			} catch(e) {
       				error = new Error('Body reply is not a valid JSON string.');
       				error.runkeeperBody = body;
+              error.statusCode = response.statusCode;
+              error.statusMessage = response.statusMessage;
       			} finally {
               callback(error, parsed);
       			}

--- a/lib/runkeeper.js
+++ b/lib/runkeeper.js
@@ -4,29 +4,29 @@ var request = require('request');
 // Predefined API Routes
 var API = {
     "user": {
-    	"media_type": "application/vnd.com.runkeeper.User+json",
+    	"Content-Type": "application/vnd.com.runkeeper.User+json",
     	"uri": "/user"
     }
   , "profile": {
-  		"media_type": "application/vnd.com.runkeeper.Profile+json",
+  		"Content-Type": "application/vnd.com.runkeeper.Profile+json",
 		"uri": "/profile"
 	}
   , "settings": {
-  		"media_type": "application/vnd.com.runkeeper.Settings+json",
+  		"Content-Type": "application/vnd.com.runkeeper.Settings+json",
 		"uri": "/settings"
 	}
   , "fitnessActivityFeed": {
-  		"media_type": "application/vnd.com.runkeeper.FitnessActivityFeed+json",
+  		"Content-Type": "application/vnd.com.runkeeper.FitnessActivityFeed+json",
   		"uri": "/fitnessActivities"
   	}
   , "fitnessActivities": {
-  		"media_type": "application/vnd.com.runkeeper.FitnessActivity+json",
+  		"Content-Type": "application/vnd.com.runkeeper.FitnessActivity+json",
 		"uri": "/fitnessActivities"
 	}
 };
 
 var HealthGraph = exports.HealthGraph = function(options) {
-    
+
     this.client_id = options.client_id || null ;
     this.client_secret = options.client_secret || null;
     this.auth_url = options.auth_url || "https://runkeeper.com/apps/authorize";
@@ -51,20 +51,20 @@ HealthGraph.prototype.getNewToken = function (authorization_code, callback) {
 		client_secret: this.client_secret,
 		redirect_uri: this.redirect_uri
     };
-    
+
     var paramlist  = [];
     for (pk in request_params) {
 	paramlist.push(pk + "=" + request_params[pk]);
     };
     var body_string = paramlist.join("&");
-    
-    var request_details = {  
+
+    var request_details = {
 		method: "POST",
-		headers: {'content-type' : 'application/x-www-form-urlencoded'},
+		headers: {'Content-Type' : 'application/x-www-form-urlencoded'},
 		uri: this.access_token_url,
 		body: body_string
     };
-    
+
     request(request_details, function(error, response, body) {
 	    	callback(error, JSON.parse(body)['access_token']);
 	    });
@@ -99,28 +99,25 @@ HealthGraph.prototype.apiCall = function(method, media_type, endpoint, callback)
 for (func_name in API) {
     HealthGraph.prototype[func_name] = (function(func_name) {
 	    return function(callback) {
-		var request_details = {
-		    method: API[func_name]['method'] || 'GET',
-		    headers: {'Accept': API[func_name]['media_type'],
-			      'Authorization' : 'Bearer ' + this.access_token},
-		    uri: "https://" + this.api_domain + API[func_name]['uri']
-		};
-		request(request_details,
-			function(error, response, body) { 
-				var parsed;
-				try {
-					parsed = JSON.parse(body);
-				} catch(e) {
-					error = new Error('Body reply is not a valid JSON string.');
-					error.runkeeperBody = body;
-				} finally {
-					callback(error, parsed);
-				}
-			});
-	    }; 
+      	var request_details = {
+      	    method: API[func_name]['method'] || 'GET',
+      	    headers: {'Accept': API[func_name]['media_type'],
+      		      'Authorization' : 'Bearer ' + this.access_token},
+      	    uri: "https://" + this.api_domain + API[func_name]['uri']
+      	};
+      	request(request_details,
+      		function(error, response, body) {
+      			var parsed;
+      			try {
+      				parsed = JSON.parse(body);
+      			} catch(e) {
+      				error = new Error('Body reply is not a valid JSON string.');
+      				error.runkeeperBody = body;
+      			} finally {
+              callback(error, parsed);
+      			}
+      		}
+        );
+      };
 	})(func_name);
 };
-
-
-
-


### PR DESCRIPTION
Runkeeper no longer uses media_type. Content-Type is the current header for API calls.
Add HTTP status code and status message to error.